### PR TITLE
Add Cobalt Media Downloader to tools array

### DIFF
--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -118,6 +118,11 @@ const tools: Tool[] = [
     name: 'Browser Torrent Streamer',
     url: 'https://webtor.io',
   },
+  {
+    category: 'General',
+    name: 'Cobalt Media Downloader',
+    url: 'https://cobalt.tools/',
+  },
   // Grouped by platform/site
   {
     applicableSites: ['youtube.com'],


### PR DESCRIPTION
Add Cobalt Media Downloader to the tools array in `src/entrypoints/popup/App.tsx`.

* Add a new tool object with the name "Cobalt Media Downloader" and the URL "https://cobalt.tools/" under the "General" category.
* Ensure the new tool object is placed in the appropriate position within the array, maintaining the sorted order by frequency.

